### PR TITLE
18 General WFS stored query solution

### DIFF
--- a/FMI2QGIS/core/processing/raster_loader.py
+++ b/FMI2QGIS/core/processing/raster_loader.py
@@ -1,0 +1,140 @@
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+from qgis.core import QgsTask, QgsMessageLog, Qgis, QgsRasterLayer, QgsProject
+
+from ..exceptions.loader_exceptions import BadRequestException
+from ..wfs import StoredQuery
+from ...qgis_plugin_tools.tools import network
+from ...qgis_plugin_tools.tools.custom_logging import bar_msg
+from ...qgis_plugin_tools.tools.exceptions import QgsPluginNetworkException, QgsPluginException
+from ...qgis_plugin_tools.tools.i18n import tr
+from ...qgis_plugin_tools.tools.resources import plugin_name
+
+LOGGER = logging.getLogger(plugin_name())
+
+
+class RasterLoader(QgsTask):
+    MESSAGE_CATEGORY = 'FmiRasterLoader'
+
+    def __init__(self, description: str, download_dir: Path, fmi_download_url: str, sq: StoredQuery):
+        """
+        :param download_dir:Download directory of the output file(s)
+        :param fmi_download_url: FMI download url
+        :param sq: StoredQuery
+        """
+        super().__init__(description, QgsTask.CanCancel)
+
+        self.download_dir = download_dir
+        if not self.download_dir.exists():
+            self.download_dir.mkdir()
+        self.url = fmi_download_url
+        self.sq = sq
+
+        self.path_to_file: Path = Path()
+        self.exception: Optional[Exception] = None
+
+    def run(self):
+        """
+        NOTE: LOGGER cannot be used in here or any methods that are called from here
+        :return:
+        """
+        self.path_to_file, result = self._download()
+        return result
+
+    def _download(self) -> Tuple[Path, bool]:
+        """
+        Downloads files to the disk (self.download_dir)
+        :param kwargs: keyword arguments depending on the product
+        :return: Path to the downloaded file and whether was succesful or not
+        """
+        result: bool = False
+        output: Path = Path()
+        try:
+            self.setProgress(0)
+            uri = self._construct_uri()
+            self.setProgress(10)
+            self._log(f'Started task "{self.description}"')
+
+            self._log(f'Download url is is: "{uri}"')
+
+            try:
+                # TODO: what about large files, should requests be used if available to stream content?
+                data, default_name = network.fetch_raw(uri)
+                self._log(f'File name is: "{default_name}"')
+                self.setProgress(70)
+                if not self.isCanceled():
+                    output = Path(self.download_dir, default_name)
+                    with open(output, 'wb') as f:
+                        f.write(data)
+                    self._log(f'Success!')
+                    result = True
+            except QgsPluginNetworkException as e:
+                error_message = e.bar_msg['details']
+                if 'Bad Request' in error_message:
+                    raise BadRequestException(tr('Bad request'),
+                                              bar_msg=bar_msg(tr('Try with different start and end times')))
+        except Exception as e:
+            self.exception = e
+            result = False
+
+        self.setProgress(100)
+        return output, result
+
+    def _construct_uri(self) -> str:
+        url = self.url + f'?producer={self.sq.producer}&format={self.sq.format}'
+        url += '&' + '&'.join([f'{name}={param.value}' for name, param in self.sq.parameters.items()])
+        return url
+
+    def _log(self, msg: str, level=Qgis.Info) -> None:
+        # noinspection PyCallByClass
+        QgsMessageLog.logMessage(msg, self.MESSAGE_CATEGORY, level)
+
+    def finished(self, result: bool) -> None:
+        """
+        This function is automatically called when the task has completed (successfully or not).
+
+        finished is always called from the main thread, so it's safe
+        to do GUI operations and raise Python exceptions here.
+
+        :param result: the return value from self.run
+        """
+        if result and self.path_to_file.is_file():
+            layer = self.raster_to_layer()
+            if layer.isValid():
+                # TODO: layer styling
+
+                # noinspection PyArgumentList
+                QgsProject.instance().addMapLayer(layer)
+
+        # Error handling
+        else:
+            if self.exception is None:
+                LOGGER.warning(tr('Task was not successful'), extra=bar_msg(tr('Task was probably cancelled by user')))
+            else:
+                try:
+                    raise self.exception
+                except QgsPluginException as e:
+                    LOGGER.exception(str(e), extra=e.bar_msg)
+                except Exception as e:
+                    LOGGER.exception(tr('Unhandled exception occurred'), extra=bar_msg(e))
+
+    def raster_to_layer(self) -> QgsRasterLayer:
+        """
+        TODO
+        :return:
+        """
+        # TODO: change name
+        layer_name = 'testlayer'
+        if self.path_to_file.suffix == 'nc':
+            # TODO: Check variable(s) using gdal.Dataset.GetSubDatasets()
+            variable = 'index_of_airquality_194'
+
+            uri = f'NETCDF:"{self.path_to_file}":{variable}'
+
+        else:
+            # TODO: add support for other raster formats
+            uri = str(self.path_to_file)
+        layer = QgsRasterLayer(uri, layer_name)
+        return layer

--- a/FMI2QGIS/core/wfs.py
+++ b/FMI2QGIS/core/wfs.py
@@ -1,0 +1,199 @@
+#  Gispo Ltd., hereby disclaims all copyright interest in the program FMI2QGIS
+#  Copyright (C) 2020 Gispo Ltd (https://www.gispo.fi/).
+#
+#
+#  This file is part of FMI2QGIS.
+#
+#  FMI2QGIS is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  FMI2QGIS is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with FMI2QGIS.  If not, see <https://www.gnu.org/licenses/>.
+
+import enum
+import xml.etree.ElementTree as ET
+import datetime
+from typing import List, Optional, Dict
+from urllib.parse import urlsplit, parse_qs
+
+from PyQt5.QtCore import QVariant
+
+from FMI2QGIS.definitions.configurable_settings import Namespace
+from FMI2QGIS.qgis_plugin_tools.tools.misc_utils import extent_to_bbox
+from FMI2QGIS.qgis_plugin_tools.tools.network import fetch
+
+
+class ParameterVariable:
+
+    def __init__(self, id: str, alias: str, label: str):
+        self.id = id
+        self.alias = alias
+        self.label = label
+
+
+class Parameter:
+    TYPE_DICT = {'double': QVariant.Double, 'point': QVariant.Point,
+                 'dateTime': QVariant.DateTime, 'unsignedInteger': QVariant.Int, 'pos': QVariant.Point,
+                 'boolean': QVariant.Bool, 'NameList': QVariant.StringList,
+                 'string': QVariant.String, 'int': QVariant.Int, 'integerList': QVariant.List,
+                 'bbox': QVariant.Rect, 'bbox_with_srs': QVariant.RectF}
+
+    TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'  # 2020-11-02T15:00:00Z
+
+    def __init__(self, name: str, title: str, abstract: str, type: QVariant):
+        self.name = name
+        self.title = title
+        self.abstract = abstract
+        self.type = type
+        self.variables = []
+        self._value: any = None
+
+    @staticmethod
+    def create(param: ET.Element) -> 'Parameter':
+        param_title = param.find('{%s}Title' % Namespace.WFS.value).text
+        param_abstract = param.find('{%s}Abstract' % Namespace.WFS.value).text
+        param_info = param.attrib
+        param_name = param_info['name']
+        param_type = Parameter.TYPE_DICT.get(param_info['type'].replace('xsi:', '').replace('gml:', ''))
+
+        if param_name == 'bbox':
+            if 'srs' in param_abstract:
+                param_type = Parameter.TYPE_DICT['bbox_with_srs']
+            else:
+                param_type = Parameter.TYPE_DICT['bbox']
+        if param_name == 'parameters':
+            param_name = 'param'
+        return Parameter(param_name, param_title, param_abstract, param_type)
+
+    @staticmethod
+    def _round_datetime(dt: datetime.datetime) -> datetime.datetime:
+        dt += datetime.timedelta(minutes=5)
+        dt -= datetime.timedelta(minutes=dt.minute % 10,
+                                 seconds=dt.second,
+                                 microseconds=dt.microsecond)
+        return dt
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, val: any):
+        # TODO: checks!
+        _val = val
+        if self.type == QVariant.DateTime:
+            if not isinstance(val, datetime.datetime):
+                raise ()
+            _val = datetime.datetime.strftime(self._round_datetime(val), self.TIME_FORMAT)
+        elif self.type in [QVariant.Rect, QVariant.RectF]:
+            _val = extent_to_bbox(val)
+        elif self.name == 'param':
+            if isinstance(val, list):
+                _val = ','.join(val)
+        self._value = _val
+
+    def has_variables(self) -> bool:
+        return self.name == 'param' and self.type == QVariant.StringList
+
+    def populate_variables(self, observed_property_url: str) -> None:
+        variables = []
+        url_lower = observed_property_url.lower()
+        content = fetch(observed_property_url)
+        root = ET.ElementTree(ET.fromstring(content)).getroot()
+        for component in root.findall('{%s}component' % Namespace.OMOP.value):
+            op = component.find('{%s}ObservableProperty' % Namespace.OMOP.value)
+            id = op.items()[0][-1]
+            label = op.find('{%s}label' % Namespace.OMOP.value).text
+            # Find alias for id from url, since ids are always lowercase
+            alias_idx = url_lower.find(id)
+            if alias_idx > -1:
+                alias = observed_property_url[alias_idx:alias_idx + len(id)]
+            else:
+                alias = id
+            variables.append(ParameterVariable(id, alias, label))
+        self.variables = variables
+
+
+class StoredQuery:
+    class Type(enum.Enum):
+        Raster = 'raster'
+        Vector = 'vector'
+
+    def __init__(self, sq_id: str, title: str, abstract: str, sq_type: Type, parameters: Dict[str, Parameter]):
+        self.id = sq_id
+        self.title = title
+        self.abstract = abstract
+        self.type = sq_type
+        self.parameters = parameters
+        self.producer: str = ''
+        self.format: str = ''
+
+    @staticmethod
+    def create(sq_element: ET.Element) -> Optional['StoredQuery']:
+        id = sq_element.get('id')
+        sq_type = StoredQuery.Type.Vector
+        if id.endswith('grid'):
+            sq_type = StoredQuery.Type.Raster
+        elif id.endswith('iwxxm') or id.endswith('GetFeatureById'):
+            # TODO: add support?
+            return None
+        if sq_element == StoredQuery.Type.Vector:
+            # TODO: add support for vectors
+            return None
+
+        title = sq_element.find('{%s}Title' % Namespace.WFS.value).text
+        abstract = sq_element.find('{%s}Abstract' % Namespace.WFS.value).text
+        params = [Parameter.create(param) for param in sq_element.findall('{%s}Parameter' % Namespace.WFS.value)]
+        params = {param.name: param for param in params}
+        return StoredQuery(id, title, abstract, sq_type, params)
+
+
+class StoredQueryFactory:
+
+    def __init__(self, wfs_url: str, wfs_version: str):
+        self.wfs_url = wfs_url
+        self.wfs_version = wfs_version
+
+    @property
+    def __describe_stored_queries_url(self) -> str:
+        return f'{self.wfs_url}?service=WFS&version={self.wfs_version}&request=describeStoredQueries'
+
+    def __get_feature_url(self, sq: StoredQuery, count: int):
+        # TODO: maxFeatures for version < 2.0.0
+        return (f'{self.wfs_url}?service=WFS&version={self.wfs_version}&request=GetFeature'
+                f'&count={count}&storedquery_id={sq.id}')
+
+    def list_queries(self) -> List[StoredQuery]:
+        stored_queries: List[StoredQuery] = []
+
+        content = fetch(self.__describe_stored_queries_url)
+        root = ET.ElementTree(ET.fromstring(content)).getroot()
+        for sq_element in list(root):
+            sq = StoredQuery.create(sq_element)
+            if sq:
+                stored_queries.append(sq)
+
+        return stored_queries
+
+    def expand(self, sq: StoredQuery) -> None:
+        if sq.type == StoredQuery.Type.Raster:
+            content = fetch(self.__get_feature_url(sq, 1))
+            root = ET.ElementTree(ET.fromstring(content)).getroot()
+            grid_observation_elem = list(list(root)[0])[0]
+
+            # Observed property url
+            ob_url = grid_observation_elem.find('{%s}observedProperty' % Namespace.OM.value).items()[0][-1]
+            for param in sq.parameters.values():
+                if param.has_variables():
+                    param.populate_variables(ob_url)
+
+            process_url = grid_observation_elem.find('{%s}procedure' % Namespace.OM.value).items()[0][-1]
+            sq.producer = process_url.split('/')[-1]
+            sq.format = parse_qs(urlsplit(ob_url).query).get('units', [''])[0]

--- a/FMI2QGIS/core/wfs.py
+++ b/FMI2QGIS/core/wfs.py
@@ -17,17 +17,17 @@
 #  You should have received a copy of the GNU General Public License
 #  along with FMI2QGIS.  If not, see <https://www.gnu.org/licenses/>.
 
+import datetime
 import enum
 import xml.etree.ElementTree as ET
-import datetime
 from typing import List, Optional, Dict
 from urllib.parse import urlsplit, parse_qs
 
 from PyQt5.QtCore import QVariant
 
-from FMI2QGIS.definitions.configurable_settings import Namespace
-from FMI2QGIS.qgis_plugin_tools.tools.misc_utils import extent_to_bbox
-from FMI2QGIS.qgis_plugin_tools.tools.network import fetch
+from ..definitions.configurable_settings import Namespace
+from ..qgis_plugin_tools.tools.misc_utils import extent_to_bbox
+from ..qgis_plugin_tools.tools.network import fetch
 
 
 class ParameterVariable:

--- a/FMI2QGIS/definitions/configurable_settings.py
+++ b/FMI2QGIS/definitions/configurable_settings.py
@@ -1,5 +1,21 @@
 import enum
 
+from ..qgis_plugin_tools.tools.settings import get_setting
+
+
 @enum.unique
 class Settings(enum.Enum):
-    fmi_download_url = 'https://opendata.fmi.fi/download'
+    FMI_DOWNLOAD_URL = 'https://opendata.fmi.fi/download'
+    FMI_WFS_URL = 'https://opendata.fmi.fi/wfs'
+    FMI_WFS_VERSION = '2.0.0'
+
+    def get(self, typehint: type = str) -> any:
+        """Gets the value of the setting"""
+        return get_setting(self.name, self.value, typehint)
+
+
+@enum.unique
+class Namespace(enum.Enum):
+    WFS = 'http://www.opengis.net/wfs/2.0'
+    OM = 'http://www.opengis.net/om/2.0'
+    OMOP = 'http://inspire.ec.europa.eu/schemas/omop/2.9'

--- a/FMI2QGIS/test/test_raster_loader.py
+++ b/FMI2QGIS/test/test_raster_loader.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from pathlib import Path
+
+from ..core.processing.raster_loader import RasterLoader
+from ..core.wfs import Parameter
+from ..qgis_plugin_tools.tools import network
+from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
+
+
+def test_download_enfuser(tmpdir_pth, fmi_download_url, enfuser_sq, extent_sm_1, monkeypatch):
+    enfuser_sq.parameters['starttime'].value = datetime.strptime('2020-11-05T19:00:00Z', Parameter.TIME_FORMAT)
+    enfuser_sq.parameters['endtime'].value = datetime.strptime('2020-11-06T11:00:00Z', Parameter.TIME_FORMAT)
+    enfuser_sq.parameters['bbox'].value = extent_sm_1
+    enfuser_sq.parameters['param'].value = ['AQIndex']
+
+    loader = RasterLoader('', tmpdir_pth, fmi_download_url, enfuser_sq)
+
+    test_file = Path(plugin_test_data_path('aq_small.nc'))
+    test_file_name = 'test_aq_small.nc'
+
+    def mock_fetch_raw(uri: str, encoding: str = 'utf-8'):
+        with open(test_file, 'rb') as f:
+            return f.read(), test_file_name
+
+    # Mocking the download
+    monkeypatch.setattr(network, 'fetch_raw', mock_fetch_raw)
+
+    result = loader.run()
+
+    assert result, loader.exception
+    assert loader.path_to_file == Path(tmpdir_pth, test_file_name)
+    assert loader.path_to_file.exists()
+    assert loader.path_to_file.stat().st_size == test_file.stat().st_size
+
+
+def test_construct_uri_enfuser(tmpdir_pth, fmi_download_url, enfuser_sq, extent_sm_1, monkeypatch):
+    enfuser_sq.parameters['starttime'].value = datetime.strptime('2020-11-05T19:00:00Z', Parameter.TIME_FORMAT)
+    enfuser_sq.parameters['endtime'].value = datetime.strptime('2020-11-06T11:00:00Z', Parameter.TIME_FORMAT)
+    enfuser_sq.parameters['bbox'].value = extent_sm_1
+    enfuser_sq.parameters['param'].value = ['AQIndex']
+    loader = RasterLoader('', tmpdir_pth, fmi_download_url, enfuser_sq)
+    uri = loader._construct_uri()
+
+    assert uri == ('https://opendata.fmi.fi/download?'
+                   'producer=enfuser_helsinki_metropolitan'
+                   '&format=netcdf'
+                   '&starttime=2020-11-05T19:00:00Z'
+                   '&endtime=2020-11-06T11:00:00Z'
+                   '&bbox=24.97,60.2,24.99,60.21'
+                   '&param=AQIndex')
+
+
+def test_raster_to_layer(tmpdir_pth, fmi_download_url):
+    loader = RasterLoader('', tmpdir_pth, fmi_download_url, None)
+    test_file = Path(plugin_test_data_path('aq_small.nc'))
+    loader.path_to_file = test_file
+
+    layer = loader.raster_to_layer()
+    assert layer.isValid()
+    assert layer.name() == 'testlayer'

--- a/FMI2QGIS/test/test_wfs.py
+++ b/FMI2QGIS/test/test_wfs.py
@@ -1,0 +1,42 @@
+from PyQt5.QtCore import QVariant
+
+from ..core.wfs import StoredQueryFactory, StoredQuery
+
+
+def test_factory_list_queries(wfs_url, wfs_version):
+    enfuser_id = 'fmi::forecast::enfuser::airquality::helsinki-metropolitan::grid'
+
+    factory = StoredQueryFactory(wfs_url, wfs_version)
+    queries = factory.list_queries()
+
+    raster_queries = {sq.id: sq for sq in filter(lambda q: q.type == StoredQuery.Type.Raster, queries)}
+    enfuser_sq: StoredQuery = raster_queries.get(enfuser_id)
+
+    assert len(queries) >= 100
+    assert len(raster_queries) >= 10
+    assert enfuser_id in raster_queries.keys()
+    assert enfuser_sq.producer == ''
+    assert len(enfuser_sq.parameters) == 4
+    assert set(enfuser_sq.parameters.keys()) == {'bbox', 'endtime', 'param', 'starttime'}
+    assert enfuser_sq.parameters['bbox'].type == QVariant.Rect
+    assert enfuser_sq.parameters['endtime'].type == QVariant.DateTime
+    assert enfuser_sq.parameters['param'].has_variables()
+    assert enfuser_sq.parameters['param'].variables == []
+
+
+def test_sq_expanding(wfs_url, wfs_version):
+    enfuser_id = 'fmi::forecast::enfuser::airquality::helsinki-metropolitan::grid'
+    factory = StoredQueryFactory(wfs_url, wfs_version)
+    queries = factory.list_queries()
+    enfuser_sq: StoredQuery = list(filter(lambda q: q.id == enfuser_id, queries))[0]
+
+    factory.expand(enfuser_sq)
+    param_variables = [pv.alias for pv in enfuser_sq.parameters['param'].variables]
+
+    assert enfuser_sq.producer == 'enfuser_helsinki_metropolitan'
+    assert enfuser_sq.format == 'netcdf'
+    assert param_variables == ['AQIndex',
+                               'NO2Concentration',
+                               'O3Concentration',
+                               'PM10Concentration',
+                               'PM25Concentration']

--- a/FMI2QGIS/ui/main_dialog.py
+++ b/FMI2QGIS/ui/main_dialog.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 from PyQt5.QtWidgets import QDialog, QProgressBar
 from qgis.core import (QgsCoordinateReferenceSystem, QgsApplication, QgsProcessingAlgRunnerTask, QgsProcessingContext,
@@ -9,7 +9,10 @@ from qgis.gui import QgsExtentGroupBox, QgisInterface, QgsMapCanvas
 
 from ..core.processing.algorithms import FmiEnfuserLoaderAlg
 from ..core.processing.provider import Fmi2QgisProcessingProvider
+from ..core.processing.raster_loader import RasterLoader
 from ..core.products.enfuser import EnfuserNetcdfLoader
+from ..core.wfs import StoredQueryFactory, StoredQuery, Parameter
+from ..definitions.configurable_settings import Settings
 from ..qgis_plugin_tools.tools.custom_logging import bar_msg
 from ..qgis_plugin_tools.tools.i18n import tr
 from ..qgis_plugin_tools.tools.logger_processing import LoggerProcessingFeedBack
@@ -47,7 +50,47 @@ class MainDialog(QDialog, FORM_CLASS):
 
         self.responsive_items = {self.btn_load}
 
+        self.task = None
+        self.sq_factory = StoredQueryFactory(Settings.FMI_WFS_URL.get(), Settings.FMI_WFS_VERSION.get())
+
+        # TODO: do this only on demand when refreshing
+        self.stored_queries: List[StoredQuery] = self.sq_factory.list_queries()
+
     def __load_clicked(self):
+        enfuser_id = 'fmi::forecast::enfuser::airquality::helsinki-metropolitan::grid'
+        sq: StoredQuery = list(filter(lambda q: q.id == enfuser_id, self.stored_queries))[0]
+        # TODO: do expanding on demand with button and build parameters dynamically based on sq.parameters
+        self.sq_factory.expand(sq)
+
+        sq.parameters['starttime'].value = self.dt_edit_start.dateTime().toPyDateTime()
+        sq.parameters['endtime'].value = self.dt_edit_end.dateTime().toPyDateTime()
+        sq.parameters['bbox'].value = self.extent_group_box_bbox.outputExtent()
+
+        # TODO: as said, build this dynamically based on sq.parameters
+        variables = []
+        if self.chk_box_aqi.isChecked():
+            variables.append('AQIndex')
+        if self.chk_box_pm25.isChecked():
+            variables.append('PM25Concentration')
+        if self.chk_box_pm10.isChecked():
+            variables.append('PM10Concentration')
+        if self.chk_box_no2.isChecked():
+            variables.append('NO2Concentration')
+        if self.chk_box_o3.isChecked():
+            variables.append('O3Concentration')
+        sq.parameters['param'].value = variables
+
+        output_path = Path(self.output_dir_select_btn.filePath())
+        self.task = RasterLoader('enfuser', output_path, Settings.FMI_DOWNLOAD_URL.get(), sq)
+
+        # noinspection PyUnresolvedReferences
+        self.task.progressChanged.connect(lambda: self.progress_bar.setValue(self.task.progress()))
+        # noinspection PyArgumentList
+        QgsApplication.taskManager().addTask(self.task)
+        self._disable_ui()
+
+    def __load_clicked_old(self):
+        # TODO: Remove
         params = {
             FmiEnfuserLoaderAlg.AQI: (self.chk_box_aqi.isChecked()),
             FmiEnfuserLoaderAlg.PM25: (self.chk_box_pm25.isChecked()),
@@ -59,24 +102,20 @@ class MainDialog(QDialog, FORM_CLASS):
             FmiEnfuserLoaderAlg.EXTENT: (self.extent_group_box_bbox.outputExtent()),
             FmiEnfuserLoaderAlg.OUT_DIR: self.output_dir_select_btn.filePath()
         }
-
         # noinspection PyArgumentList
         alg = QgsApplication.processingRegistry().algorithmById(
             f'{Fmi2QgisProcessingProvider.ID}:{FmiEnfuserLoaderAlg.ID}')
-
         task = QgsProcessingAlgRunnerTask(alg, params, self.context, self.feedback)
-
         # noinspection PyUnresolvedReferences
         task.executed.connect(self._alg_completed)
-
         # noinspection PyUnresolvedReferences
         task.progressChanged.connect(lambda: self.progress_bar.setValue(task.progress()))
-
         # noinspection PyArgumentList
         QgsApplication.taskManager().addTask(task)
         self._disable_ui()
 
     def _alg_completed(self, succesful: bool, results: Dict[str, any]) -> None:
+        # TODO: Remove
         self._enable_ui()
         if succesful:
             netcdf_path = Path(results[FmiEnfuserLoaderAlg.OUTPUT])


### PR DESCRIPTION
This PR:
* Reads stored queries and parameters from urls: 
   * [describeStoredQueries](https://opendata.fmi.fi/wfs?service=WFS&version=2.0.0&request=describeStoredQueries)
   * [GetFeature](http://opendata.fmi.fi/wfs?service=WFS&version=2.0.0&request=GetFeature&count=1&storedquery_id=fmi::forecast::enfuser::airquality::helsinki-metropolitan::grid) (this url in case of enfuser)
   * [observableProperty](http://opendata.fmi.fi/meta?observableProperty=forecast&param=AQIndex,NO2Concentration,O3Concentration,PM10Concentration,PM25Concentration&language=eng&units=netcdf) (this url in case of enfuser)
* Adds full(ish) support for raster formats and initial support for vector formats
* UI supports only enfuser at the moment


This PR fixes #18.