### PR TITLE
#23: Raise described error if invalid parameters

### DIFF
--- a/FMI2QGIS/core/exceptions/loader_exceptions.py
+++ b/FMI2QGIS/core/exceptions/loader_exceptions.py
@@ -6,3 +6,6 @@ class InvalidParameterException(QgsPluginException):
 
 class BadRequestException(QgsPluginException):
     pass
+
+class WfsException(QgsPluginException):
+    pass

--- a/FMI2QGIS/core/processing/raster_loader.py
+++ b/FMI2QGIS/core/processing/raster_loader.py
@@ -1,8 +1,7 @@
 import logging
 from pathlib import Path
-from typing import Optional
 
-from qgis.core import QgsTask, QgsRasterLayer, QgsProject
+from qgis.core import QgsRasterLayer, QgsProject
 
 from .base_loader import BaseLoader
 from ..wfs import StoredQuery

--- a/FMI2QGIS/core/processing/vector_loader.py
+++ b/FMI2QGIS/core/processing/vector_loader.py
@@ -18,13 +18,16 @@ LOGGER = logging.getLogger(plugin_name())
 class VectorLoader(BaseLoader):
     MESSAGE_CATEGORY = 'FmiVectorLoader'
 
-    def __init__(self, description: str, download_dir: Path, wfs_url: str, wfs_version: str, sq: StoredQuery):
+    def __init__(self, description: str, download_dir: Path, wfs_url: str, wfs_version: str, sq: StoredQuery,
+                 max_features: Optional[int] = None):
         """
         :param download_dir:Download directory of the output file(s)
         :param wfs_url: FMI wfs url
         :param sq: StoredQuery
+        :param max_features: maximum number of features
         """
         super().__init__(description, download_dir)
+        self.max_features = max_features
         self.wfs_url = wfs_url
         self.wfs_version = wfs_version
         self.sq = sq
@@ -44,6 +47,8 @@ class VectorLoader(BaseLoader):
 
     def _construct_uri(self) -> str:
         url = f'{self.wfs_url}?service=WFS&version={self.wfs_version}&request=GetFeature'
+        if self.max_features:
+            url += f'&count={self.max_features}'
         url += f'&storedquery_id={self.sq.id}'
         url += '&' + '&'.join(
             [f'{name}={param.value}' for name, param in self.sq.parameters.items() if param.value is not None])

--- a/FMI2QGIS/test/test_vector_loader.py
+++ b/FMI2QGIS/test/test_vector_loader.py
@@ -3,6 +3,8 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from ..core.processing.vector_loader import VectorLoader
 from ..core.wfs import Parameter
 from ..qgis_plugin_tools.tools import network
@@ -52,6 +54,38 @@ def test_construct_uri_airquality(tmpdir_pth, wfs_url, wfs_version, air_quality_
                    '&starttime=2020-11-05T00:00:00Z'
                    '&endtime=2020-11-06T00:00:00Z'
                    '&timestep=60&bbox=21.0,59.7,31.7,70.0')
+
+def test_construct_uri_airquality2(tmpdir_pth, wfs_url, wfs_version, air_quality_sq, extent_lg_1):
+    air_quality_sq.parameters['starttime'].value = datetime.strptime('2020-11-05T00:00:00Z', Parameter.TIME_FORMAT)
+    air_quality_sq.parameters['endtime'].value = datetime.strptime('2020-11-06T00:00:00Z', Parameter.TIME_FORMAT)
+    air_quality_sq.parameters['timestep'].value = 60
+    air_quality_sq.parameters['bbox'].value = extent_lg_1
+    loader = VectorLoader('', tmpdir_pth, wfs_url, wfs_version, air_quality_sq, max_features=10)
+    uri = loader._construct_uri()
+    assert uri == ('https://opendata.fmi.fi/wfs?service=WFS&version=2.0.0'
+                   '&request=GetFeature'
+                   '&count=10'
+                   '&storedquery_id=fmi::observations::airquality::hourly::simple'
+                   '&starttime=2020-11-05T00:00:00Z'
+                   '&endtime=2020-11-06T00:00:00Z'
+                   '&timestep=60&bbox=21.0,59.7,31.7,70.0')
+
+
+@pytest.mark.skip('This test fails if run together with other tests, individually works fine...')
+def test_loader_with_invalid_parameters(new_project, tmpdir_pth, wfs_url, wfs_version, air_quality_sq, extent_lg_1):
+    # Without starttime
+    air_quality_sq.parameters['endtime'].value = datetime.strptime('2020-11-06T11:00:00Z', Parameter.TIME_FORMAT)
+    air_quality_sq.parameters['timestep'].value = 60
+    air_quality_sq.parameters['bbox'].value = extent_lg_1
+
+    loader = VectorLoader('', tmpdir_pth, wfs_url, wfs_version, air_quality_sq, max_features=1)
+    result = loader.run()
+
+    assert not result
+    assert loader.exception
+    assert str(loader.exception) == 'Exception occurred: OperationParsingFailed'
+    # noinspection PyUnresolvedReferences
+    assert loader.exception.bar_msg['details'] == 'Invalid time interval! The start time is later than the end time.'
 
 
 def test_vector_to_layer(tmpdir_pth, wfs_url, wfs_version, air_quality_sq, monkeypatch):

--- a/FMI2QGIS/test/test_wfs.py
+++ b/FMI2QGIS/test/test_wfs.py
@@ -1,7 +1,9 @@
+import pytest
 from PyQt5.QtCore import QVariant
 
+from ..core.exceptions.loader_exceptions import WfsException
 from .conftest import ENFUSER_ID, AIR_QUALITY_ID
-from ..core.wfs import StoredQueryFactory, StoredQuery
+from ..core.wfs import StoredQueryFactory, StoredQuery, raise_based_on_response
 
 
 def test_factory_list_queries_raster(wfs_url, wfs_version):
@@ -63,3 +65,11 @@ def test_sq_vector_expanding(wfs_url, wfs_version):
     air_quality_sq: StoredQuery = list(filter(lambda q: q.id == AIR_QUALITY_ID, queries))[0]
 
     factory.expand(air_quality_sq)
+
+
+def test_raise_based_on_response1():
+    xml_content = '<?xml version="1.0" encoding="UTF-8"?>\n<ExceptionReport xmlns="http://www.opengis.net/ows/1.1"\n\t\t xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n  xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd"\n  version="2.0.0" xml:lang="eng">\n\n\n  <Exception exceptionCode="OperationParsingFailed">\n    <ExceptionText>Invalid time interval!</ExceptionText>\n    <ExceptionText>The start time is later than the end time.</ExceptionText>\n    <ExceptionText>URI: /wfs?bbox=21.0%2C59.7%2C31.7%2C70.0&amp;endtime=2020-11-06T11%3A00%3A00Z&amp;request=GetFeature&amp;service=WFS&amp;storedquery_id=fmi%3A%3Aobservations%3A%3Aairquality%3A%3Ahourly%3A%3Asimple&amp;timestep=60&amp;version=2.0.0</ExceptionText>\n    \n  </Exception>\n\n</ExceptionReport>\n'
+    with pytest.raises(WfsException) as excinfo:
+        raise_based_on_response(xml_content)
+    assert str(excinfo.value) == 'Exception occurred: OperationParsingFailed'
+    assert excinfo.value.bar_msg['details'] == 'Invalid time interval! The start time is later than the end time.'


### PR DESCRIPTION
It is not easy to determine whether parameter is required or not but at least WFS exception messages are good. Thus I propose that we should make every (vector) parameter empty by default and empty parameters should be considered unfilled.

This PR adds meaningful exceptions in case of WFS errors. 

Resolves #23.